### PR TITLE
test-tarball.sh was not cleaning properly

### DIFF
--- a/scripts/test-tarball.sh
+++ b/scripts/test-tarball.sh
@@ -16,4 +16,5 @@ cd package
 node -e "require('./index.js').install()"
 
 # cleanup
+cd ..
 npm run clean


### PR DESCRIPTION
`test-tarball.sh` script doesn't clean `package/` folder and the `tgz` file.